### PR TITLE
Refresh UI and expand platform support

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,90 +1,311 @@
+:root {
+  color-scheme: light dark;
+  --background: radial-gradient(circle at 20% 20%, #2f80ed, transparent 40%),
+    radial-gradient(circle at 80% 10%, #56ccf2, transparent 45%),
+    radial-gradient(circle at 50% 80%, #bb6bd9, transparent 40%),
+    #0f172a;
+  --panel-bg: rgba(15, 23, 42, 0.65);
+  --panel-border: rgba(255, 255, 255, 0.08);
+  --panel-shadow: 0 30px 60px rgba(15, 23, 42, 0.45);
+  --text-primary: #f8fafc;
+  --text-secondary: rgba(248, 250, 252, 0.7);
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --accent-soft: rgba(56, 189, 248, 0.12);
+  --divider: rgba(148, 163, 184, 0.25);
+  --chip-bg: rgba(148, 163, 184, 0.2);
+  --chip-active-bg: rgba(14, 165, 233, 0.25);
+  --chip-active-border: rgba(14, 165, 233, 0.9);
+  --status-bg: rgba(15, 23, 42, 0.6);
+  --status-error: rgba(248, 113, 113, 0.12);
+  --status-error-text: #fecaca;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--background);
+  color: var(--text-primary);
+  display: flex;
+  justify-content: center;
+  font-family: inherit;
+}
+
+.app-shell {
+  position: relative;
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 32px 16px 48px;
+}
+
+.gradient {
+  position: fixed;
+  inset: 0;
+  background: var(--background);
+  z-index: 0;
+}
+
 .app {
-  text-align: center;
-  min-height: 100%;
+  position: relative;
+  z-index: 1;
+  width: min(1080px, 100%);
+  backdrop-filter: blur(28px) saturate(130%);
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  box-shadow: var(--panel-shadow);
+  border-radius: 32px;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
-header {
-  height: 412px;
-  background: #F95759;
+.header {
+  padding: 48px min(72px, 8vw) 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  border-bottom: 1px solid var(--divider);
+}
+
+.brand {
   display: flex;
   align-items: center;
+  gap: 24px;
+}
+
+.brand h1 {
+  margin: 0;
+  font-size: clamp(32px, 4vw, 48px);
+  letter-spacing: -0.02em;
+}
+
+.brand p {
+  margin: 8px 0 0;
+  font-size: clamp(16px, 2vw, 18px);
+  color: var(--text-secondary);
+}
+
+.brand-badge {
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
-}
-
-main {
-  padding-bottom: 30px;
-}
-
-footer {
-  width: 100%;
-  height: 30px;
-}
-
-.center {
-  flex: 1;
-  max-width: 620px;
-}
-
-.logo {
-  color: white;
-  font-size: 60px;
-  font-family: "OriyaMN, Oriya MN";
-  font-weight: normal;
-  margin-top: 60px;
-}
-
-.description {
-  color: white;
+  width: 64px;
+  height: 64px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+  color: #0f172a;
+  font-weight: 700;
   font-size: 24px;
-  margin: 40px 0px;
+  letter-spacing: 0.08em;
 }
 
-.search {
-  height: 40px;
+.search-panel {
   display: flex;
-  margin-bottom: 10px;
+  flex-direction: column;
+  gap: 28px;
 }
 
-.search-input {
-  height: 40px;
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.field-group > label {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.field-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.search-bar {
+  display: flex;
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid transparent;
+  border-radius: 16px;
+  padding: 10px;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.search-bar:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+
+.search-bar input {
   flex: 1;
-  padding: 0px 0px 0px 10px;
-  border: 0px;
-  font-size: 18px; 
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 18px;
+  padding: 8px 12px;
+  font-family: inherit;
 }
 
-.search-button {
-  height: 40px;
-  width: 40px;
-  background: #F8E81C;
-  display: flex;
+.search-bar input::placeholder {
+  color: rgba(248, 250, 252, 0.4);
+}
+
+.search-bar input:focus {
+  outline: none;
+}
+
+.icon-button {
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  border: none;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 0px;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
 }
 
-.search-button:hover {
-  background: #BEB217;
+.icon-button:disabled {
+  opacity: 0.6;
+  cursor: wait;
 }
 
-.search-icon {
-  height: 32px;
-  width: 32px;
-  flex: 1;
+.icon-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(14, 165, 233, 0.35);
+}
+
+.icon-button img {
+  width: 22px;
+  height: 22px;
+  filter: brightness(0) invert(1);
+}
+
+.segmented {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.segmented-item {
+  flex: 1 1 120px;
+  min-width: 140px;
+  padding: 10px 16px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.45);
+  color: inherit;
+  font-size: 14px;
+  letter-spacing: -0.01em;
+  cursor: pointer;
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 150ms ease, background 150ms ease;
+}
+
+.segmented-item span {
+  font-size: 20px;
+}
+
+.segmented-item.active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.chip {
+  border: 1px solid transparent;
+  background: var(--chip-bg);
+  color: inherit;
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-size: 14px;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: border-color 150ms ease, background 150ms ease;
+}
+
+.chip.chip-active {
+  border-color: var(--chip-active-border);
+  background: var(--chip-active-bg);
 }
 
 .results {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: space-around;
+  flex-direction: column;
+  gap: 32px;
+  padding: 32px min(72px, 8vw) 48px;
 }
 
-.options {
-  color: white;
+.status {
+  align-self: center;
+  padding: 14px 20px;
+  border-radius: 14px;
+  background: var(--status-bg);
+  color: var(--text-secondary);
+  font-size: 15px;
+  letter-spacing: 0.01em;
 }
 
-.options lable {
-  margin: 0 10px;
+.status.error {
+  background: var(--status-error);
+  color: var(--status-error-text);
+}
+
+.result-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.footer {
+  margin-top: auto;
+  padding: 24px;
+  border-top: 1px solid var(--divider);
+  color: rgba(248, 250, 252, 0.6);
+  text-align: center;
+  font-size: 14px;
+}
+
+.footer a {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .app {
+    border-radius: 24px;
+  }
+
+  .header {
+    padding: 32px 24px 24px;
+  }
+
+  .results {
+    padding: 24px;
+  }
+
+  .footer {
+    padding: 20px;
+  }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,173 +1,267 @@
-import React, { Component } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import Result from './Result';
 import {
     expandShortLink,
     searchAppById,
     searchIosApp,
     searchMacApp,
+    searchVisionApp,
+    searchWatchApp,
 } from './iTunes';
-import search from './search.svg';
+import searchIcon from './search.svg';
 import './App.css';
 
-class App extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            input: '',
-            results: [],
-            country: 'US',
-            resolution: 512,
-        };
-        this.search = this.search.bind(this);
-    }
+const COUNTRY_OPTIONS = [
+    { code: 'US', label: 'United States', flag: '🇺🇸' },
+    { code: 'CN', label: 'China', flag: '🇨🇳' },
+    { code: 'JP', label: 'Japan', flag: '🇯🇵' },
+    { code: 'GB', label: 'United Kingdom', flag: '🇬🇧' },
+    { code: 'DE', label: 'Germany', flag: '🇩🇪' },
+    { code: 'FR', label: 'France', flag: '🇫🇷' },
+    { code: 'CA', label: 'Canada', flag: '🇨🇦' },
+    { code: 'AU', label: 'Australia', flag: '🇦🇺' },
+    { code: 'KR', label: 'South Korea', flag: '🇰🇷' },
+    { code: 'IN', label: 'India', flag: '🇮🇳' },
+];
 
-    async search() {
-        let { input, country } = this.state;
-        input = input.trim();
+const PLATFORM_OPTIONS = [
+    { key: 'ios', label: 'iOS & iPadOS', badge: 'iOS', search: searchIosApp },
+    { key: 'mac', label: 'macOS', badge: 'macOS', search: searchMacApp },
+    { key: 'vision', label: 'visionOS', badge: 'visionOS', search: searchVisionApp },
+    { key: 'watch', label: 'watchOS', badge: 'watchOS', search: searchWatchApp },
+];
+
+const RESOLUTION_OPTIONS = [
+    { value: 512, label: '512 × 512' },
+    { value: 1024, label: '1024 × 1024' },
+];
+
+const itunesReg = /^(http|https):\/\/itunes/;
+const idReg = /\/id(\d+)/i;
+const shortReg = /^(http|https):\/\/appsto/;
+
+function App() {
+    const [query, setQuery] = useState('');
+    const [country, setCountry] = useState('US');
+    const [resolution, setResolution] = useState(1024);
+    const [selectedPlatforms, setSelectedPlatforms] = useState(
+        PLATFORM_OPTIONS.map((platform) => platform.key)
+    );
+    const [results, setResults] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState('');
+
+    const platformMap = useMemo(() => {
+        return PLATFORM_OPTIONS.reduce((acc, platform) => {
+            acc[platform.key] = platform;
+            return acc;
+        }, {});
+    }, []);
+
+    const togglePlatform = (platformKey) => {
+        setSelectedPlatforms((prev) => {
+            if (prev.includes(platformKey)) {
+                return prev.filter((key) => key !== platformKey);
+            }
+            return [...prev, platformKey];
+        });
+    };
+
+    const dedupeResults = useCallback((apps) => {
+        const seen = new Map();
+        apps.forEach((app) => {
+            if (!seen.has(app.trackId)) {
+                seen.set(app.trackId, app);
+            }
+        });
+        return Array.from(seen.values());
+    }, []);
+
+    const performSearch = useCallback(async () => {
+        let input = query.trim();
+        if (!input) {
+            setError('Enter an app name or App Store URL to start searching.');
+            setResults([]);
+            return;
+        }
+        setLoading(true);
+        setError('');
         let url = input;
-        const itunesReg = /^(http|https):\/\/itunes/;
-        const idReg = /\/id(\d+)/i;
-        const shortReg = /^(http|https):\/\/appsto/;
 
         try {
             if (shortReg.test(input)) {
                 url = await expandShortLink(input);
             }
+
             if (itunesReg.test(url) && idReg.test(url)) {
                 const id = idReg.exec(url)[1];
                 const data = await searchAppById(id, country);
-                this.setState({ results: data.results });
-            } else {
-                const data = await Promise.all([
-                    searchIosApp(input, country),
-                    searchMacApp(input, country),
-                ]);
-                this.setState({
-                    results: data[0].results.concat(data[1].results),
-                });
+                setResults(data.results || []);
+                if (!data.results || !data.results.length) {
+                    setError('No results found for that App Store link.');
+                }
+                return;
+            }
+
+            const activePlatforms = selectedPlatforms.length
+                ? selectedPlatforms
+                : PLATFORM_OPTIONS.map((platform) => platform.key);
+
+            const platformPromises = activePlatforms.map((key) =>
+                platformMap[key]
+                    .search(input, country)
+                    .then((data) => data.results || [])
+                    .catch(() => [])
+            );
+
+            const responses = await Promise.all(platformPromises);
+            const apps = dedupeResults(responses.flat());
+            setResults(apps);
+
+            if (!apps.length) {
+                setError('No matching apps were found. Try a different query.');
             }
         } catch (err) {
             console.error(err);
+            setError('Something went wrong while contacting the App Store.');
+            setResults([]);
+        } finally {
+            setLoading(false);
         }
-    }
+    }, [
+        country,
+        dedupeResults,
+        platformMap,
+        query,
+        selectedPlatforms,
+    ]);
 
-    render() {
-        const { input, results, country, resolution } = this.state;
-        return (
+    const handleSubmit = (event) => {
+        event.preventDefault();
+        performSearch();
+    };
+
+    return (
+        <div className="app-shell">
+            <div className="gradient" />
             <div className="app">
-                <header>
-                    <div className="center">
-                        <div className="logo">HQ ICON</div>
-                        <div className="description">
-                            Get high quality icons from App Store
+                <header className="header">
+                    <div className="brand">
+                        <span className="brand-badge">HQ</span>
+                        <div>
+                            <h1>App Icon Studio</h1>
+                            <p>Download crisp icons for iOS, macOS, watchOS, and visionOS apps.</p>
                         </div>
-                        <div className="options">
-                            Country:
-                            <lable
-                                onClick={() => this.setState({ country: 'US' })}
-                            >
+                    </div>
+                    <form className="search-panel" onSubmit={handleSubmit}>
+                        <div className="field-group">
+                            <label htmlFor="query">Search the App Store</label>
+                            <div className="search-bar">
                                 <input
-                                    name="store"
-                                    type="radio"
-                                    checked={country === 'US'}
-                                />US 🇺🇸
-                            </lable>
-                            <lable
-                                onClick={() => this.setState({ country: 'CN' })}
-                            >
-                                <input
-                                    name="store"
-                                    type="radio"
-                                    checked={country === 'CN'}
-                                />CN 🇨🇳
-                            </lable>
-                            <lable
-                                onClick={() => this.setState({ country: 'JP' })}
-                            >
-                                <input
-                                    name="store"
-                                    type="radio"
-                                    checked={country === 'JP'}
-                                />JP 🇯🇵
-                            </lable>
-                        </div>
-                        <div className="options">
-                            Image Resolution:
-                            <lable
-                                onClick={() =>
-                                    this.setState({ resolution: 512 })
-                                }
-                            >
-                                <input
-                                    name="resolution"
-                                    type="radio"
-                                    checked={resolution === 512}
+                                    id="query"
+                                    type="text"
+                                    value={query}
+                                    onChange={(event) => setQuery(event.target.value)}
+                                    placeholder="Paste an App Store link or type an app name"
                                 />
-                                512x512
-                            </lable>
-                            <lable
-                                onClick={() =>
-                                    this.setState({ resolution: 1024 })
-                                }
-                            >
-                                <input
-                                    name="resolution"
-                                    type="radio"
-                                    checked={resolution === 1024}
-                                />
-                                1024x1024
-                            </lable>
-                        </div>
-                        <div className="search">
-                            <input
-                                className="search-input"
-                                placeholder="iTunes url or App name"
-                                value={input}
-                                onChange={(e) =>
-                                    this.setState({ input: e.target.value })
-                                }
-                                onKeyDown={(e) =>
-                                    e.keyCode === 13 ? this.search() : ''
-                                }
-                            />
-                            <div
-                                className="search-button"
-                                onClick={this.search}
-                            >
-                                <img
-                                    src={search}
-                                    className="search-icon"
-                                    alt="search"
-                                />
+                                <button
+                                    type="submit"
+                                    className="icon-button"
+                                    disabled={loading}
+                                >
+                                    <img src={searchIcon} alt="Search" />
+                                </button>
                             </div>
                         </div>
-                        <a
-                            className="github-button"
-                            href="https://github.com/zhangweijie-cn/hq-icon"
-                            data-style="mega"
-                            aria-label="Star zhangweijie-cn/hq-icon on GitHub"
-                        >
-                            Star
-                        </a>
-                    </div>
+                        <div className="field-grid">
+                            <div className="field-group">
+                                <label>Country</label>
+                                <div className="segmented">
+                                    {COUNTRY_OPTIONS.map((option) => (
+                                        <button
+                                            key={option.code}
+                                            type="button"
+                                            className={`segmented-item ${
+                                                country === option.code ? 'active' : ''
+                                            }`}
+                                            onClick={() => setCountry(option.code)}
+                                        >
+                                            <span role="img" aria-hidden="true">
+                                                {option.flag}
+                                            </span>
+                                            {option.label}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+                            <div className="field-group">
+                                <label>Platforms</label>
+                                <div className="chip-row">
+                                    {PLATFORM_OPTIONS.map((platform) => {
+                                        const isActive = selectedPlatforms.includes(platform.key);
+                                        return (
+                                            <button
+                                                key={platform.key}
+                                                type="button"
+                                                className={`chip ${isActive ? 'chip-active' : ''}`}
+                                                onClick={() => togglePlatform(platform.key)}
+                                            >
+                                                {platform.badge}
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                            <div className="field-group">
+                                <label>Icon resolution</label>
+                                <div className="segmented">
+                                    {RESOLUTION_OPTIONS.map((option) => (
+                                        <button
+                                            key={option.value}
+                                            type="button"
+                                            className={`segmented-item ${
+                                                resolution === option.value ? 'active' : ''
+                                            }`}
+                                            onClick={() => setResolution(option.value)}
+                                        >
+                                            {option.label}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+                    </form>
                 </header>
                 <main className="results">
-                    {results.map((result) => (
-                        <Result
-                            key={result.trackId}
-                            data={result}
-                            resolution={resolution}
-                        />
-                    ))}
+                    {loading && <div className="status">Searching the App Store…</div>}
+                    {!loading && error && <div className="status error">{error}</div>}
+                    {!loading && !error && results.length === 0 && (
+                        <div className="status">Start with a search to see app icons.</div>
+                    )}
+                    <div className="result-grid">
+                        {results.map((result) => (
+                            <Result
+                                key={result.trackId}
+                                data={result}
+                                resolution={resolution}
+                            />
+                        ))}
+                    </div>
                 </main>
                 <footer className="footer">
-                    Created by @<a href="https://github.com/zhangweijie-cn">
-                        zhangweijie-cn
+                    Built with ❤️ for app designers. View on{' '}
+                    <a
+                        href="https://github.com/zhangweijie-cn/hq-icon"
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        GitHub
                     </a>
+                    .
                 </footer>
             </div>
-        );
-    }
+        </div>
+    );
 }
 
 export default App;

--- a/src/Result.css
+++ b/src/Result.css
@@ -1,9 +1,169 @@
-.result {
-    width: 256px;
-    margin: 20px;
+.result-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 22px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 24px;
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(18px);
+  transition: transform 150ms ease, border-color 150ms ease;
+}
+
+.result-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.icon-wrapper {
+  position: relative;
+  padding: 12px;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.8);
+  display: flex;
+  justify-content: center;
 }
 
 .icon {
-    height: 256px;
-    width: 256px;
+  width: 100%;
+  border-radius: 20px;
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.55);
+  max-width: 220px;
+}
+
+.icon-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 220px;
+  height: 220px;
+  border-radius: 20px;
+  background: rgba(148, 163, 184, 0.08);
+  color: rgba(148, 163, 184, 0.8);
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.icon-skeleton {
+  width: 220px;
+  height: 220px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.2), rgba(148, 163, 184, 0.05));
+  animation: shimmer 1.6s infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    filter: brightness(0.9);
+  }
+  50% {
+    filter: brightness(1.15);
+  }
+  100% {
+    filter: brightness(0.9);
+  }
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.meta-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.platform-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-weight: 600;
+}
+
+.platform-ios {
+  background: rgba(56, 189, 248, 0.14);
+  color: #bae6fd;
+}
+
+.platform-macos {
+  background: rgba(165, 180, 252, 0.16);
+  color: #e0e7ff;
+}
+
+.platform-visionos {
+  background: rgba(94, 234, 212, 0.12);
+  color: #ccfbf1;
+}
+
+.platform-watchos {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fde68a;
+}
+
+.price {
+  font-size: 14px;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.result-card h3 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.seller {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(248, 250, 252, 0.6);
+}
+
+.meta-bottom {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 13px;
+  color: rgba(248, 250, 252, 0.6);
+}
+
+.detail {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.detail.link {
+  text-decoration: none;
+  color: #bae6fd;
+  background: rgba(56, 189, 248, 0.12);
+  transition: background 150ms ease;
+}
+
+.detail.link:hover {
+  background: rgba(56, 189, 248, 0.2);
+}
+
+@media (max-width: 480px) {
+  .result-card {
+    padding: 20px;
+  }
+
+  .icon {
+    max-width: 180px;
+  }
+
+  .icon-skeleton {
+    width: 180px;
+    height: 180px;
+  }
 }

--- a/src/Result.js
+++ b/src/Result.js
@@ -1,53 +1,97 @@
-import React, { Component } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import drawOutline from './drawOutline';
 import './Result.css';
 
-class Result extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            base64: '',
-        };
-    }
+function Result({ data, resolution }) {
+    const [base64, setBase64] = useState('');
+    const [isLoading, setIsLoading] = useState(true);
 
-    async componentDidMount() {
-        const { data, resolution } = this.props;
-        const base64 = await drawOutline(data, resolution);
-        this.setState({
-            base64,
-        });
-    }
-
-    async componentWillReceiveProps(nextProps) {
-        if (nextProps.resolution !== this.props.resolution) {
-            const { data, resolution } = nextProps;
-            const base64 = await drawOutline(data, resolution);
-            this.setState({
-                base64,
+    useEffect(() => {
+        let isMounted = true;
+        setIsLoading(true);
+        drawOutline(data, resolution)
+            .then((outline) => {
+                if (isMounted) {
+                    setBase64(outline);
+                    setIsLoading(false);
+                }
+            })
+            .catch(() => {
+                if (isMounted) {
+                    setBase64('');
+                    setIsLoading(false);
+                }
             });
-        }
-    }
+        return () => {
+            isMounted = false;
+        };
+    }, [data, resolution]);
 
-    render() {
-        const { data, resolution } = this.props;
-        const { trackName, kind } = data;
-        const { base64 } = this.state;
-        const platform = kind.startsWith('mac') ? 'mac' : 'iOS';
-        return (
-            <div className="result">
-                <a href={base64} download={`${trackName}-${platform}-${resolution}x${resolution}.png`}>
-                    <img className="icon" src={base64} alt={trackName} />
-                </a>
-                <div className="kind">{platform}</div>
-                {trackName}
+    const platform = useMemo(() => {
+        const kind = (data.kind || '').toLowerCase();
+        if (kind.includes('vision')) {
+            return 'visionOS';
+        }
+        if (kind.includes('watch')) {
+            return 'watchOS';
+        }
+        if (kind.includes('mac')) {
+            return 'macOS';
+        }
+        return 'iOS';
+    }, [data.kind]);
+
+    const fileName = `${data.trackName}-${platform}-${resolution}x${resolution}.png`;
+
+    return (
+        <article className="result-card">
+            <div className="icon-wrapper">
+                {isLoading ? (
+                    <div className="icon-skeleton" />
+                ) : base64 ? (
+                    <a href={base64} download={fileName}>
+                        <img src={base64} alt={data.trackName} className="icon" />
+                    </a>
+                ) : (
+                    <div className="icon-placeholder">Icon unavailable</div>
+                )}
             </div>
-        );
-    }
+            <div className="meta">
+                <div className="meta-top">
+                    <span className={`platform-badge platform-${platform.toLowerCase()}`}>
+                        {platform}
+                    </span>
+                    {data.formattedPrice && (
+                        <span className="price">{data.formattedPrice}</span>
+                    )}
+                </div>
+                <h3 title={data.trackName}>{data.trackName}</h3>
+                <p className="seller" title={data.sellerName}>
+                    {data.sellerName}
+                </p>
+                <div className="meta-bottom">
+                    {data.version && <span className="detail">v{data.version}</span>}
+                    {data.primaryGenreName && (
+                        <span className="detail">{data.primaryGenreName}</span>
+                    )}
+                    <a
+                        href={data.trackViewUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="detail link"
+                    >
+                        View in App Store
+                    </a>
+                </div>
+            </div>
+        </article>
+    );
 }
 
 Result.propTypes = {
     data: PropTypes.object.isRequired,
+    resolution: PropTypes.number.isRequired,
 };
 
 export default Result;

--- a/src/drawOutline.js
+++ b/src/drawOutline.js
@@ -1,6 +1,7 @@
 export default function drawOutline(data, resolution) {
     return new Promise((resolve, reject) => {
         const { artworkUrl512, kind } = data;
+        const normalizedKind = (kind || '').toLowerCase();
         const canvas = document.createElement('canvas');
         canvas.width = resolution;
         canvas.height = resolution;
@@ -15,7 +16,11 @@ export default function drawOutline(data, resolution) {
         appIcon.onload = function() {
             ctx.drawImage(appIcon, 0, 0);
             ctx.globalCompositeOperation = 'destination-in';
-            if (kind.startsWith('software')) {
+            if (
+                normalizedKind.startsWith('software') ||
+                normalizedKind.includes('vision') ||
+                normalizedKind.includes('watch')
+            ) {
                 const outline =
                     resolution === 512
                         ? new Path2D(

--- a/src/iTunes.js
+++ b/src/iTunes.js
@@ -1,19 +1,43 @@
-import fetchJsonp from 'fetch-jsonp'
+import fetchJsonp from 'fetch-jsonp';
 
-export function expandShortLink (url) {
-  return fetch(url, { method: 'HEAD' }).then(res => res.url)
+export function expandShortLink(url) {
+    return fetch(url, { method: 'HEAD' }).then((res) => res.url);
 }
 
-export function searchAppById (id, country='US') {
-  return fetchJsonp(`https://itunes.apple.com/lookup?id=${id}&country=${country}`).then(res => res.json())
+export function searchAppById(id, country = 'US') {
+    return fetchJsonp(
+        `https://itunes.apple.com/lookup?id=${id}&country=${country}`
+    ).then((res) => res.json());
 }
 
-export function searchIosApp (term, country='US', limit = 4) {
-  return fetchJsonp(`https://itunes.apple.com/search?term=${encodeURI(term)}&country=${country}&entity=software&limit=${limit}`)
-        .then(res => res.json())
+export function searchIosApp(term, country = 'US', limit = 8) {
+    return fetchJsonp(
+        `https://itunes.apple.com/search?term=${encodeURI(
+            term
+        )}&country=${country}&entity=software&limit=${limit}`
+    ).then((res) => res.json());
 }
 
-export function searchMacApp (term, country='US', limit = 4) {
-  return fetchJsonp(`https://itunes.apple.com/search?term=${encodeURI(term)}&country=${country}&entity=macSoftware&limit=${limit}`)
-        .then(res => res.json())
+export function searchMacApp(term, country = 'US', limit = 8) {
+    return fetchJsonp(
+        `https://itunes.apple.com/search?term=${encodeURI(
+            term
+        )}&country=${country}&entity=macSoftware&limit=${limit}`
+    ).then((res) => res.json());
+}
+
+export function searchVisionApp(term, country = 'US', limit = 8) {
+    return fetchJsonp(
+        `https://itunes.apple.com/search?term=${encodeURI(
+            term
+        )}&country=${country}&entity=visionOSApp&limit=${limit}`
+    ).then((res) => res.json());
+}
+
+export function searchWatchApp(term, country = 'US', limit = 8) {
+    return fetchJsonp(
+        `https://itunes.apple.com/search?term=${encodeURI(
+            term
+        )}&country=${country}&entity=watchOSApp&limit=${limit}`
+    ).then((res) => res.json());
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,15 +1,8 @@
-html {
-  height: 100%;
-}
-
-body {
+html,
+body,
+#root {
   height: 100%;
   margin: 0;
   padding: 0;
-  font-family: sans-serif;
-  background: #F7F7F7;
-}
-
-#root {
-  height: 100%;
+  font-family: inherit;
 }


### PR DESCRIPTION
## Summary
- redesign the interface with a modern glassmorphism-inspired layout and flexible controls
- add support for watchOS and visionOS app searches alongside a broader country list
- enhance result rendering with richer metadata and safer icon handling across resolutions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ff7e14bdc483289d32c3eb80f1b27b